### PR TITLE
Fix time zone method

### DIFF
--- a/lib/time_zone.js
+++ b/lib/time_zone.js
@@ -5,5 +5,5 @@ module.exports = function(country, region) {
     return null;
 
   var country = _data[country];
-  return country ? country[region || ''] : null;
+  return country ? country[region || '']||country[''] : null;
 };


### PR DESCRIPTION
Defaults to country's standard time zone if an invalid/ineffective region is set.

```
When IP is "123.63.163.228" 
getLocation outputs
{ countryCode: 'IN',
  countryName: 'India',
  region: '07',
  city: 'New Delhi',
  postalCode: null,
  latitude: 28.599999999999994,
  longitude: 77.19999999999999,
  dmaCode: 0,
  areaCode: 0,
  metroCode: 0,
  distance: [Function],
  regionName: 'Delhi' }
```

Although India follows a single timezone. And forwarding the region code to the timezone function returned undefined.
