### PR TITLE
add `maxmind.load(buffer, opts)` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ var city = cityLookup.get('66.6.44.4');
 
 var orgLookup = maxmind.openSync('/path/to/GeoOrg.mmdb');
 var organization = orgLookup.get('66.6.44.4');
+
+// You can also manually load the mmdb files into
+// memory (eg. they aren't on the same filesystem)
+
+var database = buffer;
+var cityLookup = maxmind.load(database, opts);
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require('fs');
 var Reader = require('./lib/reader');
 var ip = require('./lib/ip');
 var utils = require('./lib/utils');
+var index = require('./index');
 
 exports.Reader = Reader;
 
@@ -15,12 +16,16 @@ exports.open = function(filepath, opts, cb) {
 
   fs.readFile(filepath, function(err, database) {
     if (err) cb(err);
-    else cb(null, new Reader(database, opts));
+    else cb(null, index.load(database, opts));
   });
 };
 
 exports.openSync = function(filepath, opts) {
-  return new Reader(fs.readFileSync(filepath), opts);
+  return index.load(fs.readFileSync(filepath), opts);
+};
+
+exports.load = function(database, opts) {
+  return new Reader(database, opts);
 };
 
 exports.init = function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,26 @@
 'use strict';
 
 var assert = require('assert');
+var fs = require('fs');
 var path = require('path');
 var maxmind = require('../index');
+var Reader = require('../lib/reader');
 
 
 describe('index', function() {
   var dataDir = path.join(__dirname, 'data/test-data');
   var dbPath = path.join(dataDir, 'GeoIP2-City-Test.mmdb');
+
+  describe('load(database, opts)', function() {
+    var database = fs.readFileSync(dbPath);
+    var opts = {};
+
+    it('should return an intance of Reader', function() {
+      var reader = maxmind.load(database, opts);
+      assert.equal(reader.constructor, Reader);
+      assert.equal(reader.db, database);
+    });
+  });
 
   describe('validate()', function() {
     it('should work fine for both IPv4 and IPv6', function() {


### PR DESCRIPTION
I think it would add some flexibility to be able to load pre-opened database files, so that they don't need to be stored on the same filesystem. In our case, we're hosting the maxmind database files on Amazon S3, and have an app doing the lookup running on Heroku.

- add `maxmind.load(buffer, opts)` method to return a Reader from a database buffer
- update tests
