### PR TITLE
return an error while open db failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,15 @@ exports.open = function(filepath, opts, cb) {
     If you want to open library synchronously, use maxmind.openSync function.');
 
   fs.readFile(filepath, function(err, database) {
-    if (err) cb(err);
-    else cb(null, new Reader(database, opts));
+    if (err) {
+      cb(err);
+    } else {
+      try {
+        cb(null, new Reader(database, opts));
+      } catch (error) {
+        cb(error);
+      }
+    }    
   });
 };
 


### PR DESCRIPTION
```
/Users/thonatos/Desktop/freegeoip/node_modules/maxmind/lib/decoder.js:54
      throw new Error('Invalid Extended Type at offset ' + offset + ' val ' + tmp);
      ^

Error: Invalid Extended Type at offset 0 val 7
    at Decoder.decode (/Users/thonatos/Desktop/freegeoip/node_modules/maxmind/lib/decoder.js:54:13)
    at new Metadata (/Users/thonatos/Desktop/freegeoip/node_modules/maxmind/lib/metadata.js:15:26)
    at new Reader (/Users/thonatos/Desktop/freegeoip/node_modules/maxmind/lib/reader.js:24:19)
    at /Users/thonatos/Desktop/freegeoip/node_modules/maxmind/index.js:22:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```

open the db while we are downloading the db, there will be an error. but it seems that the error hasn't been returned.
