### PR TITLE
ip: remove duplicate function calls

### DIFF
--- a/lib/ip.js
+++ b/lib/ip.js
@@ -80,12 +80,5 @@ exports.bitAt = function(rawAddress, idx) {
 
 exports.validate = function(ip) {
   var version = net.isIP(ip);
-  switch (version) {
-    case 4:
-      return net.isIPv4(ip);
-    case 6:
-      return net.isIPv6(ip);
-    default:
-      return false;
-  }
+  return version === 4 || version === 6;
 };


### PR DESCRIPTION
This commit removes duplicate calls to net.isIPv4 and net.isIPv6.
net.isIP() returns 4 for an IPv4 address and 6 for an IPv6 address.