### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -154,7 +154,7 @@ Decoder.prototype.sizeFromCtrlByte = function(ctrlByte, offset) {
   // If the value is 30, then the size is 285 + *the next two bytes after the type
   // specifying bytes as a single unsigned integer*.
   if (size === 30)
-    return cursor(285 + this.db.readUInt16BE(offset, false), offset + 2);
+    return cursor(285 + this.db.readUInt16BE(offset), offset + 2);
 
   // At this point `size` is always 31.
   // If the value is 31, then the size is 65,821 + *the next three bytes after the
@@ -205,7 +205,7 @@ Decoder.prototype.decodePointer = function(ctrlByte, offset) {
   // bytes as a 32-bit value. In this case, the last three bits of the control byte
   // are ignored.
   } else {
-    packed = this.db.readUInt32BE(offset, true);
+    packed = this.db.readUInt32BE(offset);
   }
 
   offset += pointerSize + 1;
@@ -233,12 +233,12 @@ Decoder.prototype.decodeBoolean = function(size) {
 
 
 Decoder.prototype.decodeDouble = function(offset) {
-  return this.db.readDoubleBE(offset, true);
+  return this.db.readDoubleBE(offset);
 };
 
 
 Decoder.prototype.decodeFloat = function(offset) {
-  return this.db.readFloatBE(offset, true);
+  return this.db.readFloatBE(offset);
 };
 
 
@@ -261,7 +261,7 @@ Decoder.prototype.decodeMap = function(size, offset) {
 
 Decoder.prototype.decodeInt32 = function(offset, size) {
   if (size == 0) return 0;
-  return this.db.readInt32BE(offset, true);
+  return this.db.readInt32BE(offset);
 };
 
 
@@ -286,7 +286,7 @@ Decoder.prototype.decodeBigUint = function(offset, size) {
   var integer = 0;
   var numberOfLongs = size / 4;
   for (var i = 0; i < numberOfLongs; i++) {
-    integer = bigInt(integer).multiply(4294967296).add(buffer.readUInt32BE(i << 2, true));
+    integer = bigInt(integer).multiply(4294967296).add(buffer.readUInt32BE(i << 2));
   }
 
   return integer.toString();

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -132,11 +132,11 @@ var readNodeRight28 = function(offset) {
 };
 
 var readNodeLeft32 = function(offset) {
-  return this.db.readUInt32BE(offset, true);
+  return this.db.readUInt32BE(offset);
 };
 
 var readNodeRight32 = function(offset) {
-  return this.db.readUInt32BE(offset + 4, true);
+  return this.db.readUInt32BE(offset + 4);
 };
 
 


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395

Note: I was not able to run the test due to the following error:

```
Error: ENOENT: no such file or directory, open '/home/ruben/repos/noAssert/node-maxmind/test/data/test-data/GeoIP2-City-Test.mmdb'
```