### PR TITLE
Add default response type to Reader and remove interface prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ npm i maxmind
 
 ## Usage
 
+### JavaScript
+
 ```javascript
 var maxmind = require('maxmind');
 
@@ -43,6 +45,47 @@ var orgLookup = maxmind.openSync('/path/to/GeoOrg.mmdb');
 var organization = orgLookup.get('66.6.44.4');
 ```
 
+### TypeScript
+
+```typescript
+import * as maxmind from 'maxmind';
+
+maxmind.open<maxmind.CityResponse>('/path/to/GeoLite2-City.mmdb', (err, cityLookup) => {
+  let city = cityLookup.get('8.8.8.8'); // inferred type maxmind.CityResponse
+});
+
+
+// sync version
+
+let cityLookup = maxmind.openSync<maxmind.CityResponse>('/path/to/GeoLite2-City.mmdb');
+let city = cityLookup.get('8.8.8.8'); // inferred type maxmind.CityResponse
+
+
+// use Reader class directly
+
+let cityLookup: maxmind.Reader<maxmind.CityResponse> = null;
+myLib.downloadFromCloudToStream(someCloudMaxmindDbUrl, (err, buffer) => {
+  if (!err) {
+    cityLookup = new maxmind.Reader(buffer);
+  }
+});
+
+if (cityLookup) {
+  let city = cityLookup.get('8.8.8.8'); // inferred type maxmind.CityResponse
+}
+```
+
+Supported response types:
+
+```
+- CountryResponse
+- CityResponse
+- AnonymousIPResponse
+- AsnResponse
+- ConnectionTypeResponse
+- DomainResponse
+- IspResponse
+```
 
 ## V6 Support
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 export interface OpenOpts {
   cache?: {
-    max?: number,
-    maxAge?: number;
+    max: number,
   };
   watchForUpdates?: boolean;
   watchForUpdatesNonPersistent?: boolean;
@@ -174,10 +173,10 @@ export class Reader<T extends Response = any> {
   constructor(buffer: Buffer, opts?: OpenOpts);
 }
 
-export type openCb = (err: Error, cb: Reader) => void;
+export type openCb<T extends Response = any> = (err: Error, cb: Reader<T>) => void;
 
-export function open(filepath: string, opts?: OpenOpts | openCb, cb?: openCb): void;
+export function open<T extends Response = any>(filepath: string, opts?: OpenOpts | openCb<T>, cb?: openCb<T>): void;
 
-export function openSync(filepath: string, opts?: OpenOpts): Reader;
+export function openSync<T extends Response = any>(filepath: string, opts?: OpenOpts): Reader<T>;
 
 export function validate(ipAddress: string): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,87 +1,88 @@
-export interface IOpenOpts {
+export interface OpenOpts {
   cache?: {
-    max: number,
+    max?: number,
+    maxAge?: number;
   };
   watchForUpdates?: boolean;
   watchForUpdatesNonPersistent?: boolean;
   watchForUpdatesHook?: () => void;
 }
 
-export interface INames {
-  de?: string;
-  en: string;
-  es?: string;
-  fr?: string;
-  ja?: string;
-  'pt-BR'?: string;
-  ru?: string;
-  'zh-CN'?: string;
+export interface Names {
+  readonly de?: string;
+  readonly en: string;
+  readonly es?: string;
+  readonly fr?: string;
+  readonly ja?: string;
+  readonly 'pt-BR'?: string;
+  readonly ru?: string;
+  readonly 'zh-CN'?: string;
 }
 
-export interface ICity {
-  confidence?: number;
-  geoname_id: number;
-  names: INames;
+export interface CityRecord {
+  readonly confidence?: number;
+  readonly geoname_id: number;
+  readonly names: Names;
 }
 
-export interface IContinent {
-  code: 'AF' | 'AN' | 'AS' | 'EU' | 'NA' | 'OC' | 'SA';
-  geoname_id: number;
-  names: INames;
+export interface ContinentRecord {
+  readonly code: 'AF' | 'AN' | 'AS' | 'EU' | 'NA' | 'OC' | 'SA';
+  readonly geoname_id: number;
+  readonly names: Names;
 }
 
-export interface IBaseCountry {
-  geoname_id: number;
-  is_in_european_union?: boolean;
-  iso_code: string;
-  names: INames;
+export interface RegisteredCountryRecord {
+  readonly geoname_id: number;
+  readonly is_in_european_union?: boolean;
+  readonly iso_code: string;
+  readonly names: Names;
 }
 
-export interface ICountry extends IBaseCountry {
-  confidence?: number;
+export interface CountryRecord extends RegisteredCountryRecord {
+  readonly confidence?: number;
 }
 
-export interface ILocation {
-  accuracy_radius?: number;
-  average_income?: number;
-  latitude?: number;
-  longitude?: number;
-  metro_code?: number;
-  population_density?: number;
-  time_zone?: string;
+export interface LocationRecord {
+  readonly accuracy_radius: number;
+  readonly average_income?: number;
+  readonly latitude: number;
+  readonly longitude: number;
+  readonly metro_code?: number;
+  readonly population_density?: number;
+  readonly time_zone?: string;
 }
 
-export interface IPostal {
-  code?: string;
-  confidence?: number;
+export interface PostalRecord {
+  readonly code: string;
+  readonly confidence?: number;
 }
 
-export interface IRepresentedCountry extends IBaseCountry {
-  type: string;
+export interface RepresentedCountryRecord extends RegisteredCountryRecord {
+  readonly type: string;
 }
 
-export interface ISubdivisions {
-  confidence?: number;
-  geoname_id?: number;
-  iso_code?: string;
-  names?: INames;
+export interface SubdivisionsRecord {
+  readonly confidence?: number;
+  readonly geoname_id: number;
+  readonly iso_code: string;
+  readonly names: Names;
 }
 
-export interface ITraits {
-  autonomous_system_number?: number;
-  autonomous_system_organization?: string;
-  domain?: string;
-  ip_address: string;
-  is_anonymous?: boolean;
-  is_anonymous_proxy?: boolean;
-  is_anonymous_vpn?: boolean;
-  is_hosting_provider?: boolean;
-  is_public_proxy?: boolean;
-  is_satellite_provider?: boolean;
-  is_tor_exit_node?: boolean;
-  isp?: string;
-  organization?: string;
-  user_type?: 'business'
+export interface TraitsRecord {
+  readonly autonomous_system_number?: number;
+  readonly autonomous_system_organization?: string;
+  readonly domain?: string;
+  ip_address?: string;
+  readonly is_anonymous?: boolean;
+  readonly is_anonymous_proxy?: boolean;
+  readonly is_anonymous_vpn?: boolean;
+  readonly is_hosting_provider?: boolean;
+  readonly is_public_proxy?: boolean;
+  readonly is_satellite_provider?: boolean;
+  readonly is_tor_exit_node?: boolean;
+  readonly isp?: string;
+  readonly organization?: string;
+  readonly user_type?: 'business'
   | 'cafe'
   | 'cellular'
   | 'college'
@@ -98,82 +99,85 @@ export interface ITraits {
   | 'traveler';
 }
 
-export interface ICountryResponse {
-  continent?: IContinent;
-  country?: ICountry;
-  registered_country?: IBaseCountry;
-  represented_country?: IRepresentedCountry;
-  traits?: ITraits;
+export interface CountryResponse {
+  readonly continent?: ContinentRecord;
+  readonly country?: CountryRecord;
+  readonly registered_country?: RegisteredCountryRecord;
+  readonly represented_country?: RepresentedCountryRecord;
+  readonly traits?: TraitsRecord;
 }
 
-export interface ICityResponse extends ICountryResponse {
-  city?: ICity;
-  location?: ILocation;
-  postal?: IPostal;
-  subdivisions?: ISubdivisions[];
+export interface CityResponse extends CountryResponse {
+  readonly city?: CityRecord;
+  readonly location?: LocationRecord;
+  readonly postal?: PostalRecord;
+  readonly subdivisions?: SubdivisionsRecord[];
 }
 
-export interface IAnonymousIPResponse {
-  ip_address: string;
-  is_anonymous?: boolean;
-  is_anonymous_proxy?: boolean;
-  is_anonymous_vpn?: boolean;
-  is_hosting_provider?: boolean;
-  is_public_proxy?: boolean;
-  is_tor_exit_node?: boolean;
+export interface AnonymousIPResponse {
+  ip_address?: string;
+  readonly is_anonymous?: boolean;
+  readonly is_anonymous_proxy?: boolean;
+  readonly is_anonymous_vpn?: boolean;
+  readonly is_hosting_provider?: boolean;
+  readonly is_public_proxy?: boolean;
+  readonly is_tor_exit_node?: boolean;
 }
 
-export interface IAsnResponse {
-  autonomous_system_number: number;
-  autonomous_system_organization: string;
-  ip_address: string;
+export interface AsnResponse {
+  readonly autonomous_system_number: number;
+  readonly autonomous_system_organization: string;
+  ip_address?: string;
 }
 
-export interface IConnectionTypeResponse {
-  connection_type: string;
-  ip_address: string;
+export interface ConnectionTypeResponse {
+  readonly connection_type: string;
+  ip_address?: string;
 }
 
-export interface IDomainResponse {
-  domain: string;
-  ip_address: string;
+export interface DomainResponse {
+  readonly domain: string;
+  ip_address?: string;
 }
 
-export interface IIspResponse extends IAsnResponse {
-  isp: string;
-  organization: string;
+export interface IspResponse extends AsnResponse {
+  readonly isp: string;
+  readonly organization: string;
 }
 
-export interface IMetadata {
-  binaryFormatMajorVersion: number;
-  binaryFormatMinorVersion: number;
-  buildEpoch: Date;
-  databaseType: string;
-  languages: string[];
-  description: any;
-  ipVersion: number;
-  nodeCount: number;
-  recordSize: number;
-  nodeByteSize: number;
-  searchTreeSize: number;
-  treeDepth: number;
+export type Response = CountryResponse
+  | CityResponse
+  | AnonymousIPResponse
+  | AsnResponse
+  | ConnectionTypeResponse
+  | DomainResponse
+  | IspResponse;
+
+export interface Metadata {
+  readonly binaryFormatMajorVersion: number;
+  readonly binaryFormatMinorVersion: number;
+  readonly buildEpoch: Date;
+  readonly databaseType: string;
+  readonly languages: string[];
+  readonly description: any;
+  readonly ipVersion: number;
+  readonly nodeCount: number;
+  readonly recordSize: number;
+  readonly nodeByteSize: number;
+  readonly searchTreeSize: number;
+  readonly treeDepth: number;
 }
 
-export interface IReader {
-  get: (ipAddress: string) => ICityResponse | null;
-  metadata: IMetadata;
+export class Reader<T extends Response = any> {
+  public metadata: Metadata;
+  public get: (ipAddress: string) => T | null;
+  constructor(buffer: Buffer, opts?: OpenOpts);
 }
 
-export class Reader implements IReader {
-  public metadata: IMetadata;
-  public get: (ipAddress: string) => ICityResponse | null;
-  constructor(buffer: Buffer, opts?: IOpenOpts);
-}
+export type openCb = (err: Error, cb: Reader) => void;
 
-export type openCb = (err: Error, cb: IReader) => void;
+export function open(filepath: string, opts?: OpenOpts | openCb, cb?: openCb): void;
 
-export function open(filepath: string, opts?: IOpenOpts | openCb, cb?: openCb): void;
-
-export function openSync(filepath: string, opts?: IOpenOpts): IReader;
+export function openSync(filepath: string, opts?: OpenOpts): Reader;
 
 export function validate(ipAddress: string): boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,12 @@
       "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "10.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -319,7 +325,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1159,8 +1164,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -1371,7 +1375,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -1445,8 +1448,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1638,7 +1640,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1963,8 +1964,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -2048,7 +2048,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2095,8 +2094,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -2362,8 +2360,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -2920,8 +2917,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tiny-lru": "^1.6.1"
   },
   "devDependencies": {
+    "@types/node": "^10.12.2",
     "eslint": "2.13.1",
     "github-publish-release": "5.0.1",
     "ip-address": "5.8.9",

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,10 @@
 {
   "extends": "tslint:recommended",
   "rules": {
+    "interface-name": [
+      true,
+      "never-prefix"
+    ],
     "quotemark": [
       true,
       "single"


### PR DESCRIPTION
**Breaking changes** (for typescript users)

Fixes #125, in particular removes interface prefixing
Also a bit of cleanup in response to https://github.com/runk/node-maxmind/pull/126

@omar84 Do you mind taking a look?