### PR TITLE
Prune test artifacts from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 benchmark/*.mmdb
+scripts
+test
 coverage
+.nyc_output
 .DS_Store


### PR DESCRIPTION
Drop test artifacts from npm package.

```
2.1M    node_modules/maxmind//test
 12K    node_modules/maxmind//scripts
 36K    node_modules/maxmind//lib
 88K    node_modules/maxmind//.nyc_output
2.2M    node_modules/maxmind/
```

This saves a few megs on docker images.