### PR TITLE
Fix assert message

### DIFF
--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -6,7 +6,7 @@ import utils from './utils';
 
 assert(
   typeof BigInt !== 'undefined',
-  'Apparently you are using old version of node. Please upgrade to node 0.10 or above.'
+  'Apparently you are using old version of node. Please upgrade to node 10.x or above.'
 );
 
 const types = [

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -6,7 +6,7 @@ import utils from './utils';
 
 assert(
   typeof BigInt !== 'undefined',
-  'Apparently you are using old version of node. Please upgrade to node 10.x or above.'
+  'Apparently you are using old version of node. Please upgrade to node 10.4.x or above.'
 );
 
 const types = [


### PR DESCRIPTION
Incorrect message was shown when BigInt isn't available in node.
It showed that node version is older and has to be upgraded to 0.10 or above, whereas BigInt was introduced in node in version 10.4.0.
