### PR TITLE
fix(cicd): Build before release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 script:
   - npm run lint
   - npm test --coverage
+  - npm run build
 
 jobs:
   include:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:types": "tsc --noEmit",
     "test": "jest",
+    "prepublish": "npm run build",
     "semantic-release": "semantic-release"
   }
 }


### PR DESCRIPTION
I wasn't careful enough when added automated releases via `semantic-release`. Adding a pre-publish hook so that source code actually gets compiled before sending it to npm.