### PR TITLE
Correct handling of IPv4 start nodes

### DIFF
--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -136,6 +136,16 @@ describe('maxmind', () => {
     });
   });
 
+  describe('no IPv4 search tree', () => {
+    it('IPv4 lookup should return correct data', async () => {
+      const geoIp = await maxmind.open(
+        path.join(dataDir, 'MaxMind-DB-no-ipv4-search-tree.mmdb')
+      );
+      assert.equal(geoIp.get('1.1.1.1'), '::0/64');
+      assert.equal(geoIp.get('::1.1.1.1'), '::0/64');
+    });
+  });
+
   describe('section: binary search tree', () => {
     const files = [
       'GeoIP2-Anonymous-IP-Test',

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -99,8 +99,7 @@ describe('reader', () => {
           read(dataDir, 'MaxMind-DB-no-ipv4-search-tree.mmdb')
         );
         assert.equal(reader.findAddressInTree('::1:ffff:ffff'), 80);
-        // TODO: perhaps null should be returned here, note that pointer is larger than file itself
-        assert.equal(reader.findAddressInTree('1.1.1.1'), 4811873);
+        assert.equal(reader.findAddressInTree('1.1.1.1'), 80);
       });
 
       it('should behave fine when search tree is broken', () => {


### PR DESCRIPTION
Previously, the reader assumed that the IPv4 start would always be the
96th node. This is incorrect. The format does not specify the location
of the nodes in the database besides node 0. It is an artifact of the
current implementation of the MMDB writer that the 96th node is
generally the IPv4 start.

Also, a database may not have an IPv4 subtree at all, as in the case of
`MaxMind-DB-no-ipv4-search-tree.mmdb`, where there is one record that
cover all of the IPv4 space and it is higher up in the tree.