### PR TITLE
Update tests

### DIFF
--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -155,8 +155,8 @@ describe('maxmind', () => {
       'GeoIP2-Domain-Test',
       'GeoIP2-Enterprise-Test',
       'GeoIP2-ISP-Test',
-      'GeoIP2-Precision-City-Test',
-      'GeoIP2-Precision-ISP-Test',
+      'GeoIP2-Precision-Enterprise-Test',
+      'GeoLite2-ASN-Test',
     ];
 
     const tester = (geoIp: Reader<Response>, data: any) => {

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -38,32 +38,32 @@ describe('maxmind', () => {
         path.join(dataDir, 'GeoIP2-City-Test.mmdb')
       );
       const data = actual('GeoIP2-City-Test.json');
-      assert.deepEqual(geoIp.get('1.1.1.1'), null);
+      assert.deepStrictEqual(geoIp.get('1.1.1.1'), null);
 
-      assert.deepEqual(geoIp.get('175.16.198.255'), null);
-      assert.deepEqual(
+      assert.deepStrictEqual(geoIp.get('175.16.198.255'), null);
+      assert.deepStrictEqual(
         geoIp.get('175.16.199.1'),
         data.get('::175.16.199.0/120')
       );
-      assert.deepEqual(
+      assert.deepStrictEqual(
         geoIp.get('175.16.199.255'),
         data.get('::175.16.199.0/120')
       );
-      assert.deepEqual(
+      assert.deepStrictEqual(
         geoIp.get('::175.16.199.255'),
         data.get('::175.16.199.0/120')
       );
-      assert.deepEqual(geoIp.get('175.16.200.1'), null);
+      assert.deepStrictEqual(geoIp.get('175.16.200.1'), null);
 
-      assert.deepEqual(
+      assert.deepStrictEqual(
         geoIp.get('2a02:cf40:ffff::'),
         data.get('2a02:cf40::/29')
       );
-      assert.deepEqual(
+      assert.deepStrictEqual(
         geoIp.get('2a02:cf47:0000::'),
         data.get('2a02:cf40::/29')
       );
-      assert.deepEqual(geoIp.get('2a02:cf48:0000::'), null);
+      assert.deepStrictEqual(geoIp.get('2a02:cf48:0000::'), null);
     });
 
     it('should handle corrupt database', async () => {
@@ -89,7 +89,7 @@ describe('maxmind', () => {
       const geoIp = await maxmind.open(
         path.join(dataDir, 'MaxMind-DB-test-decoder.mmdb')
       );
-      assert.deepEqual(geoIp.get('::1.1.1.1'), {
+      assert.deepStrictEqual(geoIp.get('::1.1.1.1'), {
         array: [1, 2, 3],
         boolean: true,
         bytes: Buffer.from([0, 0, 0, 42]),
@@ -110,7 +110,7 @@ describe('maxmind', () => {
       const geoIp = await maxmind.open(
         path.join(dataDir, 'MaxMind-DB-test-decoder.mmdb')
       );
-      assert.deepEqual(geoIp.get('::0.0.0.0'), {
+      assert.deepStrictEqual(geoIp.get('::0.0.0.0'), {
         array: [],
         boolean: false,
         bytes: Buffer.from([]),
@@ -118,10 +118,10 @@ describe('maxmind', () => {
         float: 0,
         int32: 0,
         map: {},
-        uint128: '0',
+        uint128: 0,
         uint16: 0,
         uint32: 0,
-        uint64: '0',
+        uint64: 0,
         utf8_string: '',
       });
     });
@@ -130,9 +130,9 @@ describe('maxmind', () => {
       const geoIp = await maxmind.open(
         path.join(dataDir, 'MaxMind-DB-string-value-entries.mmdb')
       );
-      assert.equal(geoIp.get('1.1.1.1'), '1.1.1.1/32');
-      assert.equal(geoIp.get('1.1.1.2'), '1.1.1.2/31');
-      assert.equal(geoIp.get('175.2.1.1'), null);
+      assert.strictEqual(geoIp.get('1.1.1.1'), '1.1.1.1/32');
+      assert.strictEqual(geoIp.get('1.1.1.2'), '1.1.1.2/31');
+      assert.strictEqual(geoIp.get('175.2.1.1'), null);
     });
   });
 
@@ -141,8 +141,8 @@ describe('maxmind', () => {
       const geoIp = await maxmind.open(
         path.join(dataDir, 'MaxMind-DB-no-ipv4-search-tree.mmdb')
       );
-      assert.equal(geoIp.get('1.1.1.1'), '::0/64');
-      assert.equal(geoIp.get('::1.1.1.1'), '::0/64');
+      assert.strictEqual(geoIp.get('1.1.1.1'), '::0/64');
+      assert.strictEqual(geoIp.get('::1.1.1.1'), '::0/64');
     });
   });
 
@@ -165,12 +165,12 @@ describe('maxmind', () => {
         // TODO: check random address from the subnet?
         // see http://ip-address.js.org/#address4/biginteger
         // see https://github.com/andyperlitch/jsbn
-        assert.deepEqual(
+        assert.deepStrictEqual(
           geoIp.get(ip.startAddress().address),
           data.hash[subnet],
           subnet
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           geoIp.get(ip.endAddress().address),
           data.hash[subnet],
           subnet

--- a/src/decoder.test.ts
+++ b/src/decoder.test.ts
@@ -22,7 +22,7 @@ describe('lib/decoder', () => {
         1
       );
 
-      assert.equal(decoder.decodeUint(1, 32), 0);
+      assert.strictEqual(decoder.decodeUint(1, 32), 0);
     });
   });
 
@@ -39,28 +39,28 @@ describe('lib/decoder', () => {
     const decoder = new Decoder(Buffer.from([0x01, 0x02, 0x03, 0x04]));
 
     it('should return correct value (size <29)', () => {
-      assert.deepEqual(decoder.sizeFromCtrlByte(60, 0), {
+      assert.deepStrictEqual(decoder.sizeFromCtrlByte(60, 0), {
         value: 28,
         offset: 0,
       });
     });
 
     it('should return correct value (size = 29)', () => {
-      assert.deepEqual(decoder.sizeFromCtrlByte(61, 0), {
+      assert.deepStrictEqual(decoder.sizeFromCtrlByte(61, 0), {
         value: 30,
         offset: 1,
       });
     });
 
     it('should return correct value (size = 30)', () => {
-      assert.deepEqual(decoder.sizeFromCtrlByte(62, 0), {
+      assert.deepStrictEqual(decoder.sizeFromCtrlByte(62, 0), {
         value: 543,
         offset: 2,
       });
     });
 
     it('should return correct value (size = 31)', () => {
-      assert.deepEqual(decoder.sizeFromCtrlByte(63, 0), {
+      assert.deepStrictEqual(decoder.sizeFromCtrlByte(63, 0), {
         value: 131872,
         offset: 3,
       });
@@ -71,28 +71,28 @@ describe('lib/decoder', () => {
     const decoder = new Decoder(Buffer.from([0x01, 0x02, 0x03, 0x04]));
 
     it('should return correct value (pointer size = 0)', () => {
-      assert.deepEqual(decoder.decodePointer(39, 0), {
+      assert.deepStrictEqual(decoder.decodePointer(39, 0), {
         value: 1793,
         offset: 1,
       });
     });
 
     it('should return correct value (pointer size = 1)', () => {
-      assert.deepEqual(decoder.decodePointer(45, 0), {
+      assert.deepStrictEqual(decoder.decodePointer(45, 0), {
         value: 329986,
         offset: 2,
       });
     });
 
     it('should return correct value (pointer size = 2)', () => {
-      assert.deepEqual(decoder.decodePointer(48, 0), {
+      assert.deepStrictEqual(decoder.decodePointer(48, 0), {
         value: 592387,
         offset: 3,
       });
     });
 
     it('should return correct value (pointer size = 3)', () => {
-      assert.deepEqual(decoder.decodePointer(56, 0), {
+      assert.deepStrictEqual(decoder.decodePointer(56, 0), {
         value: 16909060,
         offset: 4,
       });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,9 +28,9 @@ describe('index', () => {
 
   describe('validate()', () => {
     it('should work fine for both IPv4 and IPv6', () => {
-      assert.equal(maxmind.validate('64.4.4.4'), true);
-      assert.equal(maxmind.validate('2001:4860:0:1001::3004:ef68'), true);
-      assert.equal(maxmind.validate('whhaaaazza'), false);
+      assert.strictEqual(maxmind.validate('64.4.4.4'), true);
+      assert.strictEqual(maxmind.validate('2001:4860:0:1001::3004:ef68'), true);
+      assert.strictEqual(maxmind.validate('whhaaaazza'), false);
     });
   });
 
@@ -84,7 +84,7 @@ describe('index', () => {
       await maxmind
         .open('/foo/bar')
         .then(nah)
-        .catch((err) => assert.equal(err.code, 'ENOENT'));
+        .catch((err) => assert.strictEqual(err.code, 'ENOENT'));
     });
 
     it('should throw an error when callback provided', async () => {
@@ -105,7 +105,7 @@ describe('index', () => {
         .open(badPath)
         .then(nah)
         .catch((err) =>
-          assert.equal(
+          assert.strictEqual(
             err.message,
             'Looks like you are passing in a file in gzip format, please use mmdb database instead.'
           )
@@ -118,7 +118,7 @@ describe('index', () => {
     //     // Indeed couter is kinda gross.
     //     switch (counter++) {
     //       case 0:
-    //         assert.equal(err, null);
+    //         assert.strictEqual(err, null);
     //         assert(reader instanceof Reader);
     //         assert(fs.readFile.calledOnce);
     //         fs.readFile.restore();
@@ -129,7 +129,7 @@ describe('index', () => {
     //         break;
 
     //       case 1:
-    //         assert.equal(err.message, 'Crazy shit');
+    //         assert.strictEqual(err.message, 'Crazy shit');
     //         done();
     //         break;
 

--- a/src/ip.test.ts
+++ b/src/ip.test.ts
@@ -5,14 +5,14 @@ describe('lib/ip', () => {
   describe('parse()', () => {
     describe('ipv4', () => {
       it('should successfully parse v4', () => {
-        assert.deepEqual(ip.parse('127.0.0.1'), [0x7f, 0x00, 0x00, 0x01]);
-        assert.deepEqual(ip.parse('10.10.200.59'), [0x0a, 0x0a, 0xc8, 0x3b]);
+        assert.deepStrictEqual(ip.parse('127.0.0.1'), [0x7f, 0x00, 0x00, 0x01]);
+        assert.deepStrictEqual(ip.parse('10.10.200.59'), [0x0a, 0x0a, 0xc8, 0x3b]);
       });
     });
 
     describe('ipv6', () => {
       it('should parse complete address', () => {
-        assert.deepEqual(ip.parse('2001:0db8:85a3:0042:1000:8a2e:0370:7334'), [
+        assert.deepStrictEqual(ip.parse('2001:0db8:85a3:0042:1000:8a2e:0370:7334'), [
           0x20,
           0x1,
           0xd,
@@ -30,7 +30,7 @@ describe('lib/ip', () => {
           0x73,
           0x34,
         ]);
-        assert.deepEqual(ip.parse('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), [
+        assert.deepStrictEqual(ip.parse('2001:0db8:85a3:0000:0000:8a2e:0370:7334'), [
           0x20,
           0x01,
           0x0d,
@@ -51,7 +51,7 @@ describe('lib/ip', () => {
       });
 
       it('should parse two-part address', () => {
-        assert.deepEqual(ip.parse('2001:4860:0:1001::3004:ef68'), [
+        assert.deepStrictEqual(ip.parse('2001:4860:0:1001::3004:ef68'), [
           0x20,
           0x01,
           0x48,
@@ -69,7 +69,7 @@ describe('lib/ip', () => {
           0xef,
           0x68,
         ]);
-        assert.deepEqual(ip.parse('2001:db8:85a3::8a2e:370:7334'), [
+        assert.deepStrictEqual(ip.parse('2001:db8:85a3::8a2e:370:7334'), [
           0x20,
           0x01,
           0x0d,
@@ -108,8 +108,8 @@ describe('lib/ip', () => {
           0,
           0,
         ];
-        assert.deepEqual(ip.parse('2001:200::'), expected);
-        assert.deepEqual(
+        assert.deepStrictEqual(ip.parse('2001:200::'), expected);
+        assert.deepStrictEqual(
           ip.parse('2001:0200:0000:0000:0000:0000:0000:0000'),
           expected
         );
@@ -117,14 +117,14 @@ describe('lib/ip', () => {
 
       it('should parse ipv4 with `::ffff`', () => {
         const expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 1, 2, 254, 216];
-        assert.deepEqual(ip.parse('::ffff:1.2.254.216'), expected);
-        assert.deepEqual(ip.parse('::ffff:0102:fed8'), expected);
-        assert.deepEqual(ip.parse('::ffff:102:fed8'), expected);
-        assert.deepEqual(
+        assert.deepStrictEqual(ip.parse('::ffff:1.2.254.216'), expected);
+        assert.deepStrictEqual(ip.parse('::ffff:0102:fed8'), expected);
+        assert.deepStrictEqual(ip.parse('::ffff:102:fed8'), expected);
+        assert.deepStrictEqual(
           ip.parse('0000:0000:0000:0000:0000:ffff:0102:fed8'),
           expected
         );
-        assert.deepEqual(
+        assert.deepStrictEqual(
           ip.parse('0000:0000:0000:0000:0000:ffff:102:fed8'),
           expected
         );
@@ -132,9 +132,9 @@ describe('lib/ip', () => {
 
       it('should parse ipv4 with `::`', () => {
         const expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 17, 254, 216];
-        assert.deepEqual(ip.parse('::64.17.254.216'), expected);
-        assert.deepEqual(ip.parse('::4011:fed8'), expected);
-        assert.deepEqual(
+        assert.deepStrictEqual(ip.parse('::64.17.254.216'), expected);
+        assert.deepStrictEqual(ip.parse('::4011:fed8'), expected);
+        assert.deepStrictEqual(
           ip.parse('0000:0000:0000:0000:0000:0000:4011:fed8'),
           expected
         );
@@ -145,27 +145,27 @@ describe('lib/ip', () => {
   describe('bitAt()', () => {
     it('should return correct bit for given offset', () => {
       const address = Buffer.from([0x0a, 0x0a, 0xc8, 0x3b]);
-      assert.equal(ip.bitAt(address, 1), 0);
-      assert.equal(ip.bitAt(address, 10), 0);
-      assert.equal(ip.bitAt(address, 23), 0);
-      assert.equal(ip.bitAt(address, 31), 1);
-      assert.equal(ip.bitAt(address, 999), 0);
+      assert.strictEqual(ip.bitAt(address, 1), 0);
+      assert.strictEqual(ip.bitAt(address, 10), 0);
+      assert.strictEqual(ip.bitAt(address, 23), 0);
+      assert.strictEqual(ip.bitAt(address, 31), 1);
+      assert.strictEqual(ip.bitAt(address, 999), 0);
     });
   });
 
   describe('validate()', () => {
     it('should work fine for IPv4', () => {
-      assert.equal(ip.validate('64.4.4.4'), true);
-      assert.equal(ip.validate('64.4.4.boom!'), false);
+      assert.strictEqual(ip.validate('64.4.4.4'), true);
+      assert.strictEqual(ip.validate('64.4.4.boom!'), false);
       // @ts-ignore
-      assert.equal(ip.validate(undefined), false);
-      assert.equal(ip.validate('kraken'), false);
+      assert.strictEqual(ip.validate(undefined), false);
+      assert.strictEqual(ip.validate('kraken'), false);
     });
 
     it('should work fine for IPv6', () => {
-      assert.equal(ip.validate('2001:4860:0:1001::3004:ef68'), true);
-      assert.equal(ip.validate('::64.17.254.216'), true);
-      assert.equal(ip.validate('2001:4860:0:1001::3004:boom!'), false);
+      assert.strictEqual(ip.validate('2001:4860:0:1001::3004:ef68'), true);
+      assert.strictEqual(ip.validate('::64.17.254.216'), true);
+      assert.strictEqual(ip.validate('2001:4860:0:1001::3004:boom!'), false);
     });
   });
 });

--- a/src/is-gzip.test.ts
+++ b/src/is-gzip.test.ts
@@ -3,11 +3,11 @@ import isGzip from './is-gzip';
 
 describe('lib/is-gzip', () => {
   it('should return false for short buffers', () => {
-    assert.equal(isGzip(Buffer.from([1, 2])), false);
+    assert.strictEqual(isGzip(Buffer.from([1, 2])), false);
   });
 
   it('should return false for string buffer', () => {
-    assert.equal(isGzip(Buffer.from('kraken')), false);
+    assert.strictEqual(isGzip(Buffer.from('kraken')), false);
   });
 
   it('should return false for string buffer', () => {
@@ -17,6 +17,6 @@ describe('lib/is-gzip', () => {
       'H4sIAGBDv1gAA8suSsxOzeMCAKjj9U8HAAAA',
       'base64'
     );
-    assert.equal(isGzip(buffer), true);
+    assert.strictEqual(isGzip(buffer), true);
   });
 });

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -17,16 +17,16 @@ describe('reader', () => {
     it('should return correct value: city database', () => {
       const reader = new Reader(read(dataDir, 'GeoIP2-City-Test.mmdb'));
       assert.equal(reader.findAddressInTree('1.1.1.1'), null);
-      assert.equal(reader.findAddressInTree('175.16.199.1'), 3042);
-      assert.equal(reader.findAddressInTree('175.16.199.88'), 3042);
-      assert.equal(reader.findAddressInTree('175.16.199.255'), 3042);
-      assert.equal(reader.findAddressInTree('::175.16.199.255'), 3042);
-      assert.equal(reader.findAddressInTree('::ffff:175.16.199.255'), 3042);
-      assert.equal(reader.findAddressInTree('2a02:cf40:ffff::'), 4735);
-      assert.equal(reader.findAddressInTree('2a02:cf47:0000::'), 4735);
+      assert.equal(reader.findAddressInTree('175.16.199.1'), 3383);
+      assert.equal(reader.findAddressInTree('175.16.199.88'), 3383);
+      assert.equal(reader.findAddressInTree('175.16.199.255'), 3383);
+      assert.equal(reader.findAddressInTree('::175.16.199.255'), 3383);
+      assert.equal(reader.findAddressInTree('::ffff:175.16.199.255'), 3383);
+      assert.equal(reader.findAddressInTree('2a02:cf40:ffff::'), 5114);
+      assert.equal(reader.findAddressInTree('2a02:cf47:0000::'), 5114);
       assert.equal(
         reader.findAddressInTree('2a02:cf47:0000:fff0:ffff::'),
-        4735
+        5114
       );
       assert.equal(reader.findAddressInTree('2a02:cf48:0000::'), null);
     });
@@ -35,33 +35,33 @@ describe('reader', () => {
       const reader = new Reader(
         read(dataDir, 'MaxMind-DB-string-value-entries.mmdb')
       );
-      assert.equal(reader.findAddressInTree('1.1.1.1'), 98);
-      assert.equal(reader.findAddressInTree('1.1.1.2'), 87);
+      assert.equal(reader.findAddressInTree('1.1.1.1'), 225);
+      assert.equal(reader.findAddressInTree('1.1.1.2'), 214);
       assert.equal(reader.findAddressInTree('175.2.1.1'), null);
     });
 
     describe('various record sizes and ip versions', () => {
       const ips = {
         v4: {
-          '1.1.1.1': 102,
-          '1.1.1.2': 90,
-          '1.1.1.32': 114,
+          '1.1.1.1': 229,
+          '1.1.1.2': 217,
+          '1.1.1.32': 241,
           '1.1.1.33': null,
         },
         v6: {
           '::1:ffff:fffa': null,
-          '::1:ffff:ffff': 176,
-          '::2:0000:0000': 194,
+          '::1:ffff:ffff': 432,
+          '::2:0000:0000': 450,
           '::2:0000:0060': null,
         },
         mix: {
-          '1.1.1.1': 315,
-          '1.1.1.2': 301,
-          '1.1.1.32': 329,
+          '1.1.1.1': 518,
+          '1.1.1.2': 504,
+          '1.1.1.32': 532,
           '1.1.1.33': null,
           '::1:ffff:fffa': null,
-          '::1:ffff:ffff': 344,
-          '::2:0000:0000': 362,
+          '::1:ffff:ffff': 547,
+          '::2:0000:0000': 565,
           '::2:0000:0060': null,
         },
       };
@@ -107,8 +107,8 @@ describe('reader', () => {
         const reader = new Reader(
           read(dataDir, 'MaxMind-DB-test-broken-search-tree-24.mmdb')
         );
-        assert.equal(reader.findAddressInTree('1.1.1.1'), 102);
-        assert.equal(reader.findAddressInTree('1.1.1.2'), 90);
+        assert.equal(reader.findAddressInTree('1.1.1.1'), 229);
+        assert.equal(reader.findAddressInTree('1.1.1.2'), 217);
       });
     });
 

--- a/src/reader.test.ts
+++ b/src/reader.test.ts
@@ -11,33 +11,33 @@ describe('reader', () => {
   describe('findAddressInTree()', () => {
     it('should work for most basic case', () => {
       const reader = new Reader(read(dataDir, 'GeoIP2-City-Test.mmdb'));
-      assert.equal(reader.findAddressInTree('1.1.1.1'), null);
+      assert.strictEqual(reader.findAddressInTree('1.1.1.1'), null);
     });
 
     it('should return correct value: city database', () => {
       const reader = new Reader(read(dataDir, 'GeoIP2-City-Test.mmdb'));
-      assert.equal(reader.findAddressInTree('1.1.1.1'), null);
-      assert.equal(reader.findAddressInTree('175.16.199.1'), 3383);
-      assert.equal(reader.findAddressInTree('175.16.199.88'), 3383);
-      assert.equal(reader.findAddressInTree('175.16.199.255'), 3383);
-      assert.equal(reader.findAddressInTree('::175.16.199.255'), 3383);
-      assert.equal(reader.findAddressInTree('::ffff:175.16.199.255'), 3383);
-      assert.equal(reader.findAddressInTree('2a02:cf40:ffff::'), 5114);
-      assert.equal(reader.findAddressInTree('2a02:cf47:0000::'), 5114);
-      assert.equal(
+      assert.strictEqual(reader.findAddressInTree('1.1.1.1'), null);
+      assert.strictEqual(reader.findAddressInTree('175.16.199.1'), 3383);
+      assert.strictEqual(reader.findAddressInTree('175.16.199.88'), 3383);
+      assert.strictEqual(reader.findAddressInTree('175.16.199.255'), 3383);
+      assert.strictEqual(reader.findAddressInTree('::175.16.199.255'), 3383);
+      assert.strictEqual(reader.findAddressInTree('::ffff:175.16.199.255'), 3383);
+      assert.strictEqual(reader.findAddressInTree('2a02:cf40:ffff::'), 5114);
+      assert.strictEqual(reader.findAddressInTree('2a02:cf47:0000::'), 5114);
+      assert.strictEqual(
         reader.findAddressInTree('2a02:cf47:0000:fff0:ffff::'),
         5114
       );
-      assert.equal(reader.findAddressInTree('2a02:cf48:0000::'), null);
+      assert.strictEqual(reader.findAddressInTree('2a02:cf48:0000::'), null);
     });
 
     it('should return correct value: string entries', () => {
       const reader = new Reader(
         read(dataDir, 'MaxMind-DB-string-value-entries.mmdb')
       );
-      assert.equal(reader.findAddressInTree('1.1.1.1'), 225);
-      assert.equal(reader.findAddressInTree('1.1.1.2'), 214);
-      assert.equal(reader.findAddressInTree('175.2.1.1'), null);
+      assert.strictEqual(reader.findAddressInTree('1.1.1.1'), 225);
+      assert.strictEqual(reader.findAddressInTree('1.1.1.2'), 214);
+      assert.strictEqual(reader.findAddressInTree('175.2.1.1'), null);
     });
 
     describe('various record sizes and ip versions', () => {
@@ -87,7 +87,7 @@ describe('reader', () => {
           const reader = new Reader(read(dataDir, '' + item));
           const list = scenarios[item];
           for (const ip in list) {
-            assert.equal(reader.findAddressInTree(ip), list[ip], 'IP: ' + ip);
+            assert.strictEqual(reader.findAddressInTree(ip), list[ip], 'IP: ' + ip);
           }
         });
       }
@@ -98,8 +98,8 @@ describe('reader', () => {
         const reader = new Reader(
           read(dataDir, 'MaxMind-DB-no-ipv4-search-tree.mmdb')
         );
-        assert.equal(reader.findAddressInTree('::1:ffff:ffff'), 80);
-        assert.equal(reader.findAddressInTree('1.1.1.1'), 80);
+        assert.strictEqual(reader.findAddressInTree('::1:ffff:ffff'), 80);
+        assert.strictEqual(reader.findAddressInTree('1.1.1.1'), 80);
       });
 
       it('should behave fine when search tree is broken', () => {
@@ -107,8 +107,8 @@ describe('reader', () => {
         const reader = new Reader(
           read(dataDir, 'MaxMind-DB-test-broken-search-tree-24.mmdb')
         );
-        assert.equal(reader.findAddressInTree('1.1.1.1'), 229);
-        assert.equal(reader.findAddressInTree('1.1.1.2'), 217);
+        assert.strictEqual(reader.findAddressInTree('1.1.1.1'), 229);
+        assert.strictEqual(reader.findAddressInTree('1.1.1.2'), 217);
       });
     });
 


### PR DESCRIPTION
This updates the tests to not use deprecated `assert` methods. It also update the test data submodule to a recent version. Both of these required minor changes to the contents of the tests.