### PR TITLE
Use `fs.watchFile` instead of `fs.watch` to detect changes to loaded database file

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -4,6 +4,5 @@ import util from 'util';
 export default {
   existsSync: fs.existsSync,
   readFile: util.promisify(fs.readFile),
-  readFileSync: fs.readFileSync,
-  watch: fs.watch,
+  watchFile: fs.watchFile,
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,11 +15,10 @@ describe('index', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     // @ts-ignore
-    sandbox.stub(fs, 'watch').callsFake((paramA, paramB, cb) => {
+    sandbox.stub(fs, 'watchFile').callsFake((paramA, paramB, cb) => {
       watchHandler = cb;
     });
     sandbox.spy(fs, 'readFile');
-    sandbox.spy(fs, 'readFileSync');
   });
   afterEach(() => {
     sandbox.restore();
@@ -51,7 +50,7 @@ describe('index', () => {
       const options = { cache: { max: 1000 }, watchForUpdates: true };
       const lookup = await maxmind.open(dbPath, options);
       assert(lookup.get('2001:230::'));
-      assert((fs.watch as SinonSpy).calledOnce);
+      assert((fs.watchFile as SinonSpy).calledOnce);
       assert((fs.readFile as SinonSpy).calledOnce);
     });
 
@@ -59,7 +58,7 @@ describe('index', () => {
       const options = { watchForUpdates: true };
       const lookup = await maxmind.open(dbPath, options);
       assert(lookup.get('2001:230::'));
-      assert((fs.watch as SinonSpy).calledOnce);
+      assert((fs.watchFile as SinonSpy).calledOnce);
       assert((fs.readFile as SinonSpy).calledOnce);
       watchHandler();
       assert((fs.readFile as SinonSpy).calledTwice);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,7 +60,7 @@ describe('index', () => {
       assert(lookup.get('2001:230::'));
       assert((fs.watchFile as SinonSpy).calledOnce);
       assert((fs.readFile as SinonSpy).calledOnce);
-      watchHandler();
+      await watchHandler();
       assert((fs.readFile as SinonSpy).calledTwice);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,18 @@ export const open = async <T>(
     fs.watchFile(filepath, watcherOptions, async () => {
       // When database file is being replaced,
       // it could be removed for a fraction of a second.
-      if (!fs.existsSync(filepath)) {
+      const waitExists = async () => {
+        for (let i = 0; i < 3; i++) {
+          if (fs.existsSync(filepath)) {
+            return true;
+          }
+
+          await new Promise(a => setTimeout(a, 500));
+        }
+
+        return false;
+      }
+      if (!(await waitExists())) {
         return;
       }
       const updateDatabase = await fs.readFile(filepath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export const open = async <T>(
       persistent: opts.watchForUpdatesNonPersistent !== true,
     };
 
-    fs.watch(filepath, watcherOptions, async () => {
+    fs.watchFile(filepath, watcherOptions, async () => {
       // When database file is being replaced,
       // it could be removed for a fraction of a second.
       if (!fs.existsSync(filepath)) {


### PR DESCRIPTION
Under certain conditions (for example D4M with mounted volumes), `fs.watch` does not trigger a re-creation event when the file is removed and re-created. Switching to `fs.watchFile` avoids this issue.

Additionally, I have added 3 attempts to find the file on disk before "failing" in the watcher callback.