### PR TITLE
minor: Reduce default cache size to 10_000 items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 npm-debug.log
 .nyc_output
 lib
+.vscode

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Dmitry Shirokov
+Copyright (c) 2024 Dmitry Shirokov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ _maxmind.open(filepath, [options])_
 - `filepath`: `<string>` Path to the binary mmdb database file.
 - `options`: `<Object>`
   - `cache`: `<Object>` Cache options. Under the bonnet module uses [tiny-lru](https://github.com/avoidwork/tiny-lru) cache.
-    - `max`: `<number>` Max cache items to keep in memory. _Default_: `6000`.
+    - `max`: `<number>` Max cache items to keep in memory. _Default_: `10_000`.
   - `watchForUpdates`: `<boolean>` Supports reloading the reader when changes occur to the database that is loaded. _Default_: `false`.
-  - `watchForUpdatesNonPersistent`: `<boolean>` Controlls wether the watcher should be persistent or not. If it is persistent, a node process will be blocked in watching state if the watcher is the only thing still running in the program. _Default_: `false`.
+  - `watchForUpdatesNonPersistent`: `<boolean>` Controls whether the watcher should be persistent or not. If it is persistent, a node process will be blocked in watching state if the watcher is the only thing still running in the program. _Default_: `false`.
   - `watchForUpdatesHook`: `<Function>` Hook function that is fired on database update. _Default_: `null`.
 
 ## Does it work in browser?

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export const open = async <T extends Response>(
     );
   }
 
-  const cache = lru(opts?.cache?.max || 60000);
+  const cache = lru(opts?.cache?.max || 10_000);
   const reader = new Reader<T>(database, { cache });
 
   if (opts && !!opts.watchForUpdates) {


### PR DESCRIPTION
- Currently it's set to 60k items which is a bit too aggressive for most users, which results in extra memory consumption.
- Align default size setting with README

Closes https://github.com/runk/node-maxmind/issues/835