### PR TITLE
Reload db when it was actually modified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,23 +48,7 @@ export const open = async <T extends Response>(
 
     fs.watchFile(filepath, watcherOptions, async (curr, prev) => {
       // Make sure file was modified, not just accessed
-      if (curr.mtimeMs === prev.mtimeMs) {
-        return;
-      }
-      // When database file is being replaced,
-      // it could be removed for a fraction of a second.
-      const waitExists = async () => {
-        for (let i = 0; i < 3; i++) {
-          if (fs.existsSync(filepath)) {
-            return true;
-          }
-
-          await new Promise((a) => setTimeout(a, 500));
-        }
-
-        return false;
-      };
-      if (!(await waitExists())) {
+      if (!curr || prev && prev.mtimeMs === curr.mtimeMs) {
         return;
       }
       const updatedDatabase = await fs.readFile(filepath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,11 @@ export const open = async <T extends Response>(
       persistent: opts.watchForUpdatesNonPersistent !== true,
     };
 
-    fs.watchFile(filepath, watcherOptions, async () => {
+    fs.watchFile(filepath, watcherOptions, async (curr, prev) => {
+      // Make sure file was modified, not just accessed
+      if (curr.mtimeMs === prev.mtimeMs) {
+        return;
+      }
       // When database file is being replaced,
       // it could be removed for a fraction of a second.
       const waitExists = async () => {


### PR DESCRIPTION
[From Node.js documentation:](https://nodejs.org/docs/latest/api/fs.html#fswatchfilefilename-options-listener)

> To be notified when the file was modified, not just accessed, it is necessary to compare `curr.mtimeMs` and `prev.mtimeMs`.