### PR TITLE
fix: Fix read file fn which uses double the memory

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -5,5 +5,6 @@ export default {
   existsSync: fs.existsSync,
   readFile: util.promisify(fs.readFile),
   watchFile: fs.watchFile,
-  createReadStream: fs.createReadStream, 
+  createReadStream: fs.createReadStream,
+  stat: util.promisify(fs.stat),
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -47,7 +47,7 @@ describe('index', () => {
       assert(lookup.get('2001:230::'));
     });
 
-    it.only('should successfully handle database, with opts', async () => {
+    it('should successfully handle database, with opts', async () => {
       const options = { cache: { max: 1000 }, watchForUpdates: true };
       const lookup = await maxmind.open(dbPath, options);
       assert(lookup.get('2001:230::'));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,6 +19,7 @@ describe('index', () => {
       watchHandler = cb;
     });
     sandbox.spy(fs, 'createReadStream');
+    sandbox.spy(fs, 'readFile');
   });
   afterEach(() => {
     sandbox.restore();
@@ -46,12 +47,12 @@ describe('index', () => {
       assert(lookup.get('2001:230::'));
     });
 
-    it('should successfully handle database, with opts', async () => {
+    it.only('should successfully handle database, with opts', async () => {
       const options = { cache: { max: 1000 }, watchForUpdates: true };
       const lookup = await maxmind.open(dbPath, options);
       assert(lookup.get('2001:230::'));
       assert((fs.watchFile as SinonSpy).calledOnce);
-      assert((fs.createReadStream as SinonSpy).calledOnce);
+      assert((fs.readFile as SinonSpy).calledOnce);
     });
 
     it('should work with auto updates', async () => {
@@ -59,9 +60,9 @@ describe('index', () => {
       const lookup = await maxmind.open(dbPath, options);
       assert(lookup.get('2001:230::'));
       assert((fs.watchFile as SinonSpy).calledOnce);
-      assert((fs.createReadStream as SinonSpy).calledOnce);
+      assert((fs.readFile as SinonSpy).calledOnce);
       await watchHandler();
-      assert((fs.createReadStream as SinonSpy).calledTwice);
+      assert((fs.readFile as SinonSpy).calledTwice);
     });
 
     it('should work with auto updates and call specified hook', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import assert, { rejects } from 'assert';
+import assert from 'assert';
 import { Reader, Response } from 'mmdb-lib';
 import { lru } from 'tiny-lru';
 import fs from './fs';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
-import assert from 'assert';
+import assert, { rejects } from 'assert';
 import { Reader, Response } from 'mmdb-lib';
 import { lru } from 'tiny-lru';
 import fs from './fs';
 import ip from './ip';
 import isGzip from './is-gzip';
 import utils from './utils';
+
+const LARGE_FILE_THRESHOLD = 512 * 1024 * 1024;
+const STREAM_WATERMARK = 8 * 1024 * 1024;
 
 type Callback = () => void;
 
@@ -17,27 +20,48 @@ export interface OpenOpts {
   watchForUpdatesHook?: Callback;
 }
 
-const readFile = async (filepath: string): Promise<Buffer> => {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
+/**
+ * Read large file in chunks.
+ *
+ * Reason it's not used for all file sizes is that it's slower than fs.readFile and uses
+ * a bit more memory due to the buffer operations.
+ *
+ * Node seems to have a limit of 2GB for fs.readFileSync, so we need to use streams for
+ * larger files.
+ *
+ * @param filepath
+ * @param size
+ * @returns
+ */
+const readLargeFile = async (filepath: string, size: number): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    let buffer = Buffer.allocUnsafe(size);
+    let offset = 0;
     const stream = fs.createReadStream(filepath, {
-      highWaterMark: 64 * 1024 * 1024, // 64 MB chunks
+      highWaterMark: STREAM_WATERMARK,
     });
 
     stream.on('data', (chunk: Buffer) => {
-      chunks.push(chunk);
+      chunk.copy(buffer, offset);
+      offset += chunk.length;
     });
 
     stream.on('end', () => {
-      resolve(Buffer.concat(chunks));
+      stream.close();
+      resolve(buffer);
     });
 
     stream.on('error', (err) => {
       reject(err);
     });
   });
-};
 
+const readFile = async (filepath: string): Promise<Buffer> => {
+  const fstat = await fs.stat(filepath);
+  return fstat.size < LARGE_FILE_THRESHOLD
+    ? fs.readFile(filepath)
+    : readLargeFile(filepath, fstat.size);
+};
 
 export const open = async <T extends Response>(
   filepath: string,


### PR DESCRIPTION
Solves https://github.com/runk/node-maxmind/issues/885

Debugging script for reference

```
const fs = require('fs');
const crypto = require('crypto');

const showMemoryUsage = () => {
  const memoryUsage = process.memoryUsage();

  console.log(`X: ${Math.round(memoryUsage.heapUsed / 1024 / 1024)} MB`);
  console.log('Memory Usage:');
  console.log(
    `- RSS (Resident Set Size): ${Math.round(memoryUsage.rss / 1024 / 1024)} MB`
  );
  console.log(
    `- Heap Total: ${Math.round(memoryUsage.heapTotal / 1024 / 1024)} MB`
  );
  console.log(
    `- Heap Used: ${Math.round(memoryUsage.heapUsed / 1024 / 1024)} MB`
  );
  console.log(
    `- External: ${Math.round(memoryUsage.external / 1024 / 1024)} MB`
  );
  console.log(
    `- Array Buffers: ${Math.round(memoryUsage.arrayBuffers / 1024 / 1024)} MB`
  );
};

// const stream = fs.createWriteStream('./data');
// for (let i = 0; i < 1000; i++) {
//   stream.write(crypto.randomBytes(1024 * 1024));
// }
// stream.end();

const readFile2 = (filepath, cb) => {
  return new Promise((resolve, reject) => {
    const stat = fs.statSync(filepath);
    let buffer = Buffer.allocUnsafe(stat.size);
    let offset = 0;
    const stream = fs.createReadStream(filepath, {
      highWaterMark: 8 * 1024 * 1024,
    });

    stream.on('data', (chunk) => {
      chunk.copy(buffer, offset);
      offset += chunk.length;
    });

    stream.on('end', () => {
      stream.close();
      resolve(buffer);
    });

    stream.on('error', (err) => {
      reject(err);
    });
  });
};

const readFileOriginal = async (filepath) => {
  return fs.readFileSync(filepath);
};

const main = async () => {
  // showMemoryUsage();
  const now = performance.now();
  // const buffer = await readFileOriginal('./data');

  const buffer = await readFile2('./data');

  console.log('took', performance.now() - now);
  console.log(buffer.length);

  setTimeout(() => {
    showMemoryUsage();
  }, 2000);
};

main().catch(console.error);
```