### PR TITLE
feat: upgrade mmdb-lib to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Mariano Facundo Scigliano @MarianoFacundoArch"
   ],
   "dependencies": {
-    "mmdb-lib": "2.2.1",
+    "mmdb-lib": "3.0.1",
     "tiny-lru": "11.3.3"
   },
   "devDependencies": {

--- a/src/__test__/integration.test.ts
+++ b/src/__test__/integration.test.ts
@@ -97,10 +97,10 @@ describe('maxmind', () => {
         float: 1.100000023841858,
         int32: -268435456,
         map: { mapX: { arrayX: [7, 8, 9], utf8_stringX: 'hello' } },
-        uint128: '1329227995784915872903807060280344576',
+        uint128: 1329227995784915872903807060280344576n,
         uint16: 100,
         uint32: 268435456,
-        uint64: '1152921504606846976',
+        uint64: 1152921504606846976n,
         utf8_string: 'unicode! ☯ - ♫',
       });
     });
@@ -117,10 +117,10 @@ describe('maxmind', () => {
         float: 0,
         int32: 0,
         map: {},
-        uint128: 0,
+        uint128: 0n,
         uint16: 0,
         uint32: 0,
-        uint64: 0,
+        uint64: 0n,
         utf8_string: '',
       });
     });
@@ -221,10 +221,10 @@ describe('maxmind', () => {
           utf8_stringX: 'hello',
         },
       },
-      uint128: '1329227995784915872903807060280344576',
+      uint128: 1329227995784915872903807060280344576n,
       uint16: 0x64,
       uint32: 268435456,
-      uint64: '1152921504606846976',
+      uint64: 1152921504606846976n,
       utf8_string: 'unicode! ☯ - ♫',
     };
     const tests = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     "removeComments": true,
     "sourceMap": true,
     "strict": true,
-    "lib": ["ES2019"],
-    "target": "ES2019"
+    "lib": ["ES2020"],
+    "target": "ES2020"
   },
   "exclude": [
     "__mocks__",


### PR DESCRIPTION
BREAKING CHANGE: Values stored in the database as uint64 or uint128
will now be decoded to BigInt. Previously, they were decoded as strings.
This change comes from mmdb-lib v3 which now uses BigInt for all 64-bit
and 128-bit unsigned integers.
